### PR TITLE
docs: plan headless mineflayer migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ node_modules/
 poetry.lock
 ckpt/
 .idea/
+.DS_Store
+build/provider-auth/
+data/evidence/
+tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# Repo Agent Notes
+
+## Current Direction
+
+This repository is now a reference and migration staging area for a new
+Minecraft agent-loop probe. Do not revive the old Voyager-style project as the
+active architecture.
+
+The next build should be zero-based and tiny:
+
+- headless local Minecraft Java server;
+- multiple mineflayer bots as NPCs;
+- no manual Minecraft client requirement;
+- no Fabric/Forge mod setup for the first proof;
+- no LLM-generated JavaScript `eval` loop;
+- a bounded tool loop where the LLM chooses the next valid tool call and
+  utterance, while the runtime validates movement, chat availability, state,
+  inventory, records, budget, and termination.
+
+## Search Index
+
+Read `docs/docs/Agent-Search-Index.md` first for routing.
+
+Important search tokens:
+
+- `MINECRAFT_AGENT_LOOP_MIGRATION`
+- `HEADLESS_MINEFLAYER_PROBE`
+- `NO_VOYAGER_EVAL_LOOP`
+- `NO_MANUAL_CLIENT_GATE`
+- `OPENAI_CODEX_PROVIDER`
+- `GAME_RUNTIME_CODEX_AUTH`
+- `CODEX_CLI_IS_NOT_GAME_PROVIDER_AUTH`
+
+## Required Reading Order
+
+1. `docs/docs/Agent-Search-Index.md`
+2. `docs/docs/Migration/agent-loop-migration.md`
+3. `docs/docs/Migration/headless-mineflayer-setup.md`
+4. `docs/docs/Migration/openai-codex-provider.md`
+5. `docs/docs/Migration/minimal-probe-goal.md`
+6. `docs/docs/Migration/handoff-gpt54-copilot.md`
+
+## Design Rules
+
+- Use Minecraft as an experiment accelerator, not as a premature replacement
+  for Dream of One.
+- The first proof is not a village simulator. It is a tiny NPC tool-loop probe.
+- Mineflayer provides the game client API. It does not provide the social
+  runtime; implement that as a small wrapper over observe, move, say, wait,
+  inspect, and remember.
+- Prefer Docker or mineflayer's `minecraft-wrap` pattern over manual server
+  setup.
+- Human visual inspection is optional. Prefer transcript, structured event log,
+  and optional prismarine-viewer/screenshot evidence.
+- Keep tests small and Detroit-style. Do not add broad mocks to create false
+  confidence.
+
+## Auth Rule
+
+When this repo says "Codex auth" for gameplay, it means game-runtime provider
+auth for the `openai-codex` provider. It does not mean Codex CLI login.
+
+Use an ignored repo-local auth store such as:
+
+```text
+build/provider-auth/openai-codex-auth.json
+```
+
+Do not inspect or print raw tokens. Do not start a browser/device login flow
+unless the auth store is missing, expired, rejected by a live smoke, or the user
+explicitly asks to refresh provider auth.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 - [📚 Analysis of Prior Projects](https://naem1023.github.io/minecraft-llm-agent-community/docs/Analysis-of-Prior-Projects)
   - [Simple Analysis of Voyager](https://naem1023.github.io/minecraft-llm-agent-community/docs/Analysis-of-Prior-Projects/voyager)
 
+## Current Migration Direction
+
+This repo is now a migration staging area for a zero-based headless mineflayer
+agent-loop probe. Read these first:
+
+- [Agent Search Index](docs/docs/Agent-Search-Index.md)
+- [Agent Loop Migration](docs/docs/Migration/agent-loop-migration.md)
+- [Headless Mineflayer Setup](docs/docs/Migration/headless-mineflayer-setup.md)
+- [OpenAI Codex Provider](docs/docs/Migration/openai-codex-provider.md)
+- [Minimal Probe Goal](docs/docs/Migration/minimal-probe-goal.md)
+- [Handoff For GPT 5.4 Copilot](docs/docs/Migration/handoff-gpt54-copilot.md)
+
+The old Voyager baseline remains useful background, but it is not the active
+architecture. The next useful proof is a tiny local server plus two mineflayer
+bots that observe, move, talk, wait, and write a transcript without requiring a
+manual Minecraft client.
+
 This project aims to observe how agents in the Minecraft world autonomously form groups and create villages. It is still in its early stages, and if valuable insights can be derived, it will be used as a research topic.
 
 This project seeks to expand the research to include how multi-agents form groups, in addition to autonomously learning skills and exploring items, based on [Voyager](https://github.com/MineDojo/Voyager).

--- a/docs/docs/Agent-Search-Index.md
+++ b/docs/docs/Agent-Search-Index.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+---
+
+# Agent Search Index
+
+Status: active migration index
+Last updated: 2026-05-19
+
+Use this file first. It exists so the next agent does not rediscover the same
+server, client, provider, and architecture decisions from chat history.
+
+## Fast Route Table
+
+| Search phrase or task | Read first | Then inspect |
+| --- | --- | --- |
+| `MINECRAFT_AGENT_LOOP_MIGRATION`, `migration`, `zero based build` | `Migration/agent-loop-migration.md` | `Migration/minimal-probe-goal.md` |
+| `HEADLESS_MINEFLAYER_PROBE`, `headless`, `server setup`, `no manual client` | `Migration/headless-mineflayer-setup.md` | `Migration/minimal-probe-goal.md` |
+| `NO_VOYAGER_EVAL_LOOP`, `Voyager`, `old repo`, `eval` | `Migration/agent-loop-migration.md` | `Analysis-of-Prior-Projects/voyager.md` |
+| `OPENAI_CODEX_PROVIDER`, `openai-codex`, `Codex provider` | `Migration/openai-codex-provider.md` | `Migration/minimal-probe-goal.md` |
+| `GAME_RUNTIME_CODEX_AUTH`, `codex auth`, `provider auth` | `Migration/openai-codex-provider.md` | root `AGENTS.md` |
+| `handoff`, `GPT 5.4 Copilot`, `next session` | `Migration/handoff-gpt54-copilot.md` | all files above |
+
+## Canonical Decision
+
+This repository should not continue by expanding the previous Voyager baseline.
+Use it as historical context only.
+
+The next useful work is a small headless mineflayer spike:
+
+```text
+local headless server
+-> two mineflayer bots
+-> small observe/move/say/wait loop
+-> transcript and event log
+-> optional browser viewer or screenshot
+```
+
+## Anti-Drift Rules
+
+- Do not make Minecraft client login or human-in-world inspection a gate.
+- Do not add Fabric/Forge mods to the first proof.
+- Do not let an LLM write arbitrary JS and `eval` it as the core loop.
+- Do not start with a full village, economy, or multi-agent society.
+- Do not confuse Codex CLI auth with game-runtime `openai-codex` provider auth.
+
+## Useful Local Repos
+
+- Current repo: `/Users/naem1023/git/minecraft-llm-agent-community`
+- Current mineflayer clone: `/Users/naem1023/git/mineflayer`
+- Dream of One direction source: `/Users/naem1023/git/dream-of-one`
+- Game Studio source: `/Users/naem1023/git/game-studio`

--- a/docs/docs/Migration/_category_.json
+++ b/docs/docs/Migration/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Migration",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "description": "Migration notes for a zero-based headless mineflayer agent-loop probe."
+  }
+}

--- a/docs/docs/Migration/agent-loop-migration.md
+++ b/docs/docs/Migration/agent-loop-migration.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 1
+---
+
+# Agent Loop Migration
+
+Status: active migration plan
+Search tokens: `MINECRAFT_AGENT_LOOP_MIGRATION`, `NO_VOYAGER_EVAL_LOOP`,
+`HEADLESS_MINEFLAYER_PROBE`.
+
+## Decision
+
+Do not revive the old project as-is. Start a zero-based, tiny mineflayer probe
+and use this repository only as reference material and migration staging.
+
+The old project was valuable because it proved that Minecraft can host LLM
+agent experiments. It is not the right active architecture now because it is
+centered on a Voyager-style loop:
+
+```text
+LLM proposes task
+-> LLM writes JavaScript action code
+-> runtime evals the code
+-> critic checks result
+-> skill library stores generated code
+```
+
+The new target is different:
+
+```text
+NPC observes current world state
+-> LLM chooses one allowed tool call and one utterance/reason
+-> runtime validates the tool call
+-> world returns a structured result
+-> NPC updates short memory
+-> repeat for a small budget
+```
+
+The LLM chooses intent. The runtime owns execution, safety, state mutation, and
+termination.
+
+## Why Migrate
+
+The previous setup made development too expensive:
+
+- manual Java server setup;
+- Fabric/mod setup;
+- manual Minecraft client connection;
+- human character in-world as the main inspection path;
+- LLM-generated JS execution as the behavior layer;
+- too much environment work before a small social result could be observed.
+
+The new setup must remove those costs first.
+
+## What To Preserve
+
+Preserve these ideas from the old repo:
+
+- Minecraft is a useful embodied testbed.
+- Mineflayer gives a rich action API for movement, chat, inventory, crafting,
+  block interaction, and entity observation.
+- Multi-agent behavior is interesting only after one small loop works.
+- Logs, observations, and skill traces were useful, but should be replaced by a
+  smaller transcript/event-ledger format.
+
+## What To Drop
+
+Drop these for the first proof:
+
+- Voyager as the active runtime;
+- generated JS skill execution;
+- Chroma skill library;
+- broad curriculum/critic agent stack;
+- Fabric server setup;
+- custom mods;
+- manual player-client inspection;
+- village/economy scope.
+
+## Migration Shape
+
+The migration should produce a new small runtime, either inside this repo or in
+a fresh sibling repo, with this shape:
+
+```text
+scripts/
+  start-headless-server.*
+  run-agent-loop-probe.*
+
+src/
+  server/
+    local-server-config
+  mineflayer/
+    create-bot
+    observe-world
+    tool-registry
+    transcript
+  agent/
+    provider-boundary
+    npc-loop
+    memory
+
+data/
+  evidence/
+    probe transcripts and screenshots
+```
+
+Do not implement all of that at once. The first coherent slice is only server
+bootstrap plus two bots exchanging one tool-loop transcript.

--- a/docs/docs/Migration/handoff-gpt54-copilot.md
+++ b/docs/docs/Migration/handoff-gpt54-copilot.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 5
+---
+
+# Handoff For GPT 5.4 Copilot
+
+Status: active handoff
+Search tokens: `GPT54_COPILOT_HANDOFF`, `HEADLESS_MINEFLAYER_PROBE`,
+`OPENAI_CODEX_PROVIDER`.
+
+## One-Line Mission
+
+Prepare and implement a zero-based headless mineflayer agent-loop probe that
+proves two Minecraft bot NPCs can observe, move, talk, wait, and adapt through
+validated tool results without manual Minecraft client inspection.
+
+## Context
+
+The old repository explored a Voyager-style Minecraft LLM agent. That is no
+longer the target architecture. The old code can be used for reference only.
+
+The new direction is closer to a constrained coding-agent loop inside
+Minecraft:
+
+```text
+observe
+-> choose one allowed tool call and utterance
+-> validate and execute through mineflayer
+-> read result
+-> update short memory
+-> repeat within a small budget
+```
+
+The LLM owns intent and wording. The runtime owns tool schemas, validation,
+world state, safety, transcript, and termination.
+
+## Read First
+
+1. `AGENTS.md`
+2. `docs/docs/Agent-Search-Index.md`
+3. `docs/docs/Migration/agent-loop-migration.md`
+4. `docs/docs/Migration/headless-mineflayer-setup.md`
+5. `docs/docs/Migration/openai-codex-provider.md`
+6. `docs/docs/Migration/minimal-probe-goal.md`
+
+## Current Repo State To Respect
+
+- Existing repo path: `/Users/naem1023/git/minecraft-llm-agent-community`
+- Existing mineflayer clone for reference: `/Users/naem1023/git/mineflayer`
+- Old untracked files may exist, including `.DS_Store` and old
+  `voyager/env/mineflayer/`; do not delete or revert them unless explicitly
+  asked.
+- `.gitignore` now ignores `.DS_Store`, `build/provider-auth/`,
+  `data/evidence/`, and `tmp/`.
+
+## Implementation Plan
+
+Keep this small. Do not build a full framework.
+
+1. Add a Node 22-oriented probe package or scripts.
+2. Add a local headless server path:
+   - prefer Docker compose with `itzg/minecraft-server:java21`, or
+   - use `minecraft-wrap` if Docker is not available.
+3. Start local server with:
+   - `ONLINE_MODE=FALSE`;
+   - flat world;
+   - creative mode;
+   - peaceful difficulty;
+   - animals/monsters off;
+   - NPC spawning on.
+4. Spawn two mineflayer bots:
+   - `npc_a`;
+   - `npc_b`;
+   - `auth: "offline"`;
+   - `viewDistance: "tiny"`.
+5. Implement tiny tools:
+   - `observe`;
+   - `move_to`;
+   - `say`;
+   - `wait`;
+   - `remember`.
+6. Implement a deterministic fake provider first.
+7. Run `agent_loop_probe_v0`:
+   - `npc_a` observes;
+   - moves near `npc_b`;
+   - says a line;
+   - handles busy/unavailable once;
+   - waits or rephrases;
+   - records memory;
+   - writes transcript.
+8. Only after the deterministic proof works, add an interface for
+   `openai-codex` provider.
+
+## Provider/Auth Rule
+
+Do not start with provider auth.
+
+When adding live provider support:
+
+- provider id: `openai-codex`;
+- auth store: `build/provider-auth/openai-codex-auth.json`;
+- model: `gpt-5.4-mini`;
+- reasoning: low;
+- no model fallback;
+- budget cap: `<= $0.01` unless user changes it.
+
+Do not run Codex CLI login for game provider auth. Codex CLI auth is not the
+same as the game runtime provider auth.
+
+## Definition Of Done For First Slice
+
+- `npm`/Node scripts can start or target a local headless server.
+- Two bots connect without a manual Minecraft client.
+- One command runs the deterministic `agent_loop_probe_v0`.
+- The run writes a transcript JSON or markdown artifact.
+- The transcript shows at least three observe/tool/result iterations.
+- One result changes the next action.
+- README and docs mention the exact run command.
+- Commit and push the coherent slice.

--- a/docs/docs/Migration/headless-mineflayer-setup.md
+++ b/docs/docs/Migration/headless-mineflayer-setup.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 2
+---
+
+# Headless Mineflayer Setup
+
+Status: active setup guide
+Search tokens: `HEADLESS_MINEFLAYER_PROBE`, `NO_MANUAL_CLIENT_GATE`,
+`MINECRAFT_SERVER_HEADLESS`.
+
+## Goal
+
+Make Minecraft testing boring:
+
+```text
+one command starts a local offline server
+one command spawns bots
+one command writes transcript/evidence
+optional browser viewer only when visual inspection is useful
+```
+
+The human should not need to open the Minecraft client for the first proof.
+
+## Recommended Server Path
+
+Use Docker first if available:
+
+```yaml
+services:
+  mc:
+    image: itzg/minecraft-server:java21
+    container_name: minecraft-agent-loop-probe
+    ports:
+      - "25565:25565"
+    environment:
+      EULA: "TRUE"
+      VERSION: "1.21.1"
+      TYPE: "VANILLA"
+      ONLINE_MODE: "FALSE"
+      MODE: "creative"
+      DIFFICULTY: "peaceful"
+      LEVEL_TYPE: "FLAT"
+      GENERATE_STRUCTURES: "false"
+      SPAWN_ANIMALS: "false"
+      SPAWN_MONSTERS: "false"
+      SPAWN_NPCS: "true"
+      VIEW_DISTANCE: "6"
+      SIMULATION_DISTANCE: "6"
+      ENABLE_COMMAND_BLOCK: "true"
+      ENABLE_RCON: "true"
+      RCON_PASSWORD: "local-dev-only"
+    volumes:
+      - ./tmp/minecraft-server:/data
+    tty: true
+    stdin_open: true
+```
+
+Use `ONLINE_MODE=FALSE` for local automation so mineflayer bots can connect
+with `auth: "offline"` and no Microsoft login.
+
+## Alternative Server Path
+
+Mineflayer's own test suite uses `minecraft-wrap` to download and start a
+vanilla server programmatically. That is a valid alternative for a Node-only
+test harness.
+
+The useful pattern in `/Users/naem1023/git/mineflayer/test/externalTest.js`:
+
+- choose a free local port;
+- download the versioned server jar;
+- start it with property overrides;
+- set `online-mode=false`;
+- set `level-type=FLAT`;
+- set `gamemode=1`;
+- set `spawn-npcs=true`;
+- connect mineflayer bot to `127.0.0.1`;
+- stop and delete server data after the run.
+
+Docker is simpler for the first project-owned spike. `minecraft-wrap` is better
+when the probe needs isolated per-test server lifecycle.
+
+## Bot Connection Baseline
+
+Use local offline auth:
+
+```js
+const mineflayer = require("mineflayer");
+
+const bot = mineflayer.createBot({
+  host: "127.0.0.1",
+  port: 25565,
+  username: "npc_a",
+  auth: "offline",
+  viewDistance: "tiny",
+});
+```
+
+Spawn multiple bots by giving each a unique username.
+
+## Observation Without Minecraft Client
+
+Use these in order:
+
+1. structured transcript;
+2. structured event log;
+3. terminal chat log;
+4. optional `prismarine-viewer` browser view;
+5. optional headless screenshot/video.
+
+`prismarine-viewer` can serve a browser view of a bot in first or third person.
+Use it for visual debugging, not as the proof gate.
+
+## First Proof Evidence
+
+Each probe run should write one small artifact:
+
+```json
+{
+  "probe": "agent_loop_probe_v0",
+  "server": "local-offline-flat",
+  "bots": ["npc_a", "npc_b"],
+  "steps": [
+    {
+      "actor": "npc_a",
+      "observation": "...",
+      "tool": "move_to",
+      "result": "arrived"
+    }
+  ],
+  "final": {
+    "status": "success",
+    "why": "npc_a handled a blocked or available conversation through tool results"
+  }
+}
+```
+
+Do not add a broad test matrix before this artifact exists.

--- a/docs/docs/Migration/minimal-probe-goal.md
+++ b/docs/docs/Migration/minimal-probe-goal.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 4
+---
+
+# Minimal Probe Goal
+
+Status: active first target
+Search tokens: `MINECRAFT_AGENT_LOOP_PROBE_V0`, `SMALLEST_PLAYABLE_PROOF`,
+`NPC_TOOL_LOOP`.
+
+## Goal
+
+Build the smallest proof that a Minecraft NPC can act like a constrained
+tool-using agent, not a scripted branch.
+
+## Scenario
+
+```text
+npc_a wants to ask npc_b for a simple answer.
+npc_b may be available or busy.
+npc_a observes the world.
+npc_a moves near npc_b.
+npc_a tries to say something.
+if npc_b is busy, npc_a waits or rephrases once.
+npc_b answers or refuses.
+npc_a writes a short memory note.
+the run saves a transcript.
+```
+
+There is no village yet. There is no economy yet. There is no custom mod yet.
+
+## Tool Set
+
+Keep the first tool set tiny:
+
+- `observe()`
+- `move_to(actorOrPosition)`
+- `say(targetActor, text)`
+- `wait(ticks, reason)`
+- `remember(note)`
+
+Optional only after the loop works:
+
+- `inspect_inventory()`
+- `inspect_nearby_blocks()`
+- `open_container(target)`
+- `trade_with_villager(target, tradeIndex)`
+
+## Acceptance Criteria
+
+The first slice is done when:
+
+- a local headless server starts without manual client steps;
+- two mineflayer bots join with offline auth;
+- `npc_a` completes at least three observe/tool/result iterations;
+- one tool result can be blocked or unavailable;
+- `npc_a` chooses a different next step after reading that result;
+- a transcript artifact is written under `data/evidence/`;
+- visual proof is optional, not required.
+
+## Non-Goals
+
+- no broad multi-agent village;
+- no Voyager skill DB;
+- no LLM-generated JS execution;
+- no Fabric/Forge mod dependency;
+- no manual Minecraft client proof;
+- no live provider dependency before deterministic loop proof.
+
+## Suggested First Commit
+
+First implementation commit should include only:
+
+- package baseline for Node 22;
+- local server start script or Docker compose;
+- bot connect script;
+- transcript writer;
+- deterministic fake provider;
+- one README section explaining how to run the probe.
+
+Do not add live OpenAI provider in the same commit unless the deterministic
+loop already works.

--- a/docs/docs/Migration/openai-codex-provider.md
+++ b/docs/docs/Migration/openai-codex-provider.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 3
+---
+
+# OpenAI Codex Provider
+
+Status: active provider guidance
+Search tokens: `OPENAI_CODEX_PROVIDER`, `GAME_RUNTIME_CODEX_AUTH`,
+`CODEX_CLI_IS_NOT_GAME_PROVIDER_AUTH`.
+
+## Meaning
+
+For this project, `openai-codex` means a game-runtime LLM provider that uses a
+Codex-compatible ChatGPT OAuth profile to call an OpenAI/Codex model for
+bounded NPC proposals.
+
+It does not mean:
+
+- run Codex CLI login;
+- call `codex auth` just because a task says "Codex auth";
+- let an LLM mutate Minecraft state directly;
+- let an LLM write arbitrary JavaScript and `eval` it as the core behavior;
+- use `OPENAI_API_KEY` as an implicit replacement without a provider decision.
+
+## Provider Role
+
+The provider may propose:
+
+- the next allowed tool call;
+- a short utterance;
+- a short reason;
+- a small memory note.
+
+The runtime must own:
+
+- Minecraft connection;
+- bot position and movement result;
+- distance and target validation;
+- chat delivery and turn/busy state;
+- inventory, container, trade, or block state;
+- transcript and evidence writing;
+- budget, timeout, fallback, and termination.
+
+## Auth Store
+
+Use an ignored repo-local auth store:
+
+```text
+build/provider-auth/openai-codex-auth.json
+```
+
+This path is ignored by `.gitignore`. Never commit provider auth.
+
+Agents may inspect whether the file exists and whether a profile is present,
+but must not print raw access tokens, refresh tokens, or cookies.
+
+## Check Order
+
+When a task says "Codex auth" in this repo:
+
+1. Confirm whether the task is about game-runtime provider auth.
+2. Inspect `build/provider-auth/openai-codex-auth.json` without printing
+   secrets.
+3. If the store exists, check profile metadata and expiry.
+4. Run a no-live-spend provider configuration check if one exists.
+5. Run a live model smoke only when the user intends to spend the small budget.
+6. Start a browser/device login flow only if the store is missing, expired,
+   rejected by live proof, or explicitly requested.
+
+## First Implementation Policy
+
+The first spike should not start with provider auth. Build this order:
+
+1. deterministic fake provider returns a valid next tool call;
+2. bot loop executes observe/move/say/wait and writes transcript;
+3. provider interface is separated from mineflayer runtime;
+4. live `openai-codex` provider is added behind the same interface;
+5. live proof uses `gpt-5.4-mini`, low reasoning, no model fallback, and a
+   small budget cap unless the user changes it.
+
+This prevents auth work from blocking the game-loop proof.
+
+## Proposed Interface
+
+```ts
+type AgentObservation = {
+  actorId: string;
+  visibleActors: Array<{ id: string; distance: number; busy: boolean }>;
+  recentChat: Array<{ from: string; text: string }>;
+  memory: string[];
+  allowedTools: string[];
+};
+
+type AgentProposal = {
+  tool: "observe" | "move_to" | "say" | "wait" | "remember";
+  args: Record<string, unknown>;
+  utterance?: string;
+  reason: string;
+  memoryNote?: string;
+};
+```
+
+The provider returns `AgentProposal`. The runtime validates it before calling
+mineflayer.


### PR DESCRIPTION
## Summary
- Add migration index and headless mineflayer probe guide.
- Define OpenAI Codex provider/auth boundary.
- Add GPT 5.4 Copilot handoff.

## Verification
- git diff --check
- npm run build --prefix docs