### PR TITLE
runtime: harden deliberation output against malformed provider fields

### DIFF
--- a/probe/src/provider/socialDeliberationProvider.ts
+++ b/probe/src/provider/socialDeliberationProvider.ts
@@ -722,6 +722,10 @@ export function parseDeliberationProviderOutput(
     social_pressure: normalizeSocialPressure(rawNextEpisode.social_pressure, currentEpisode.social_pressure),
     status: activeEpisodeStatusOrActive(rawNextEpisode.status)
   };
+  // The ActiveEpisode validator rejects a present-but-empty started_at_turn_ref.
+  if (!nonEmptyString(nextEpisode.started_at_turn_ref)) {
+    delete (nextEpisode as { started_at_turn_ref?: string }).started_at_turn_ref;
+  }
   const candidate = {
     schema: "deliberation-output/v1",
     ...body,

--- a/probe/src/provider/socialDeliberationProvider.ts
+++ b/probe/src/provider/socialDeliberationProvider.ts
@@ -24,6 +24,7 @@ import {
   buildMinecraftBasicGuideProjection,
   buildActorTurnCurrentStateProjection,
   validateDeliberationOutput,
+  stripExecutableAuthorityKeys,
   writeActiveEpisode,
   type ActiveEpisode,
   type ActorTurnCurrentStateProjection,
@@ -505,7 +506,7 @@ function normalizePlanBeadProposal(input: {
     ) {
       return undefined;
     }
-    return {
+    return stripExecutableAuthorityKeys({
       ...proposal,
       schema: "plan-bead-operation/v1",
       actor_id: nonEmptyString(proposal.actor_id) ? proposal.actor_id : input.actorId,
@@ -513,7 +514,7 @@ function normalizePlanBeadProposal(input: {
       evidence_refs: evidenceRefs,
       confidence,
       ...(patch !== undefined ? { patch } : {})
-    };
+    });
   }
 
   const title =
@@ -696,6 +697,12 @@ export function parseDeliberationProviderOutput(
     life_goal_ref: nonEmptyString(rawNextEpisode.life_goal_ref)
       ? rawNextEpisode.life_goal_ref
       : currentEpisode.life_goal_ref,
+    purpose: nonEmptyString(rawNextEpisode.purpose)
+      ? rawNextEpisode.purpose
+      : currentEpisode.purpose,
+    current_focus: nonEmptyString(rawNextEpisode.current_focus)
+      ? rawNextEpisode.current_focus
+      : currentEpisode.current_focus,
     actors_visible_or_relevant: stringArrayOr(
       rawNextEpisode.actors_visible_or_relevant,
       currentEpisode.actors_visible_or_relevant

--- a/probe/src/runtime/goals/actorEpisode/validators.ts
+++ b/probe/src/runtime/goals/actorEpisode/validators.ts
@@ -193,6 +193,28 @@ function collectExecutableAuthorityKeyErrors(value: unknown, path: string, error
   }
 }
 
+/**
+ * Deep-removes executable-authority keys (args, parameters, primitive_id, …) so a
+ * single stray field on a provider PlanBead proposal is repaired rather than
+ * failing the whole Deliberation output.
+ */
+export function stripExecutableAuthorityKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripExecutableAuthorityKeys(entry)) as unknown as T;
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (executableAuthorityKeys.has(key)) {
+      continue;
+    }
+    cleaned[key] = stripExecutableAuthorityKeys(entry);
+  }
+  return cleaned as T;
+}
+
 function validateEvidenceExpectation(value: unknown, path: string, errors: string[]) {
   if (!isRecord(value)) {
     errors.push(`${path} must be an object`);

--- a/probe/test/socialDeliberationProvider.test.ts
+++ b/probe/test/socialDeliberationProvider.test.ts
@@ -136,6 +136,36 @@ test("deterministic Deliberation provider reframes Active Episode without action
   assert.equal((output?.parsed_output as Record<string, unknown>)?.parameters, undefined);
 });
 
+test("Deliberation parser omits an empty started_at_turn_ref instead of failing validation", () => {
+  const currentEpisode = activeEpisode();
+  const result = parseDeliberationProviderOutput(
+    {
+      deliberation: {
+        rationale: "Provider emitted an empty optional episode ref.",
+        next_episode: {
+          episode_id: "episode-cycle-0002",
+          actor_id: "npc_b",
+          purpose: "Continue the prior concern with a fresh evidence-backed step.",
+          current_focus: "Use current state and visible Action Cards for the next step.",
+          opened_from_refs: ["provider-outputs/deliberation.json"],
+          started_at_turn_ref: "",
+          status: "active"
+        },
+        plan_bead_op_proposals: []
+      }
+    },
+    {
+      branchId: "branch-cycle-0001-empty-ref",
+      currentEpisodeRef: "goals/episodes/episode-cycle-0001.json",
+      currentEpisode,
+      branchEvidenceRefs: []
+    }
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.output.next_episode.started_at_turn_ref, undefined);
+});
+
 test("Deliberation parser carries current Active Episode fields and normalizes concrete PlanBead creates", () => {
   const currentEpisode = activeEpisode();
   const result = parseDeliberationProviderOutput(

--- a/probe/test/socialDeliberationProvider.test.ts
+++ b/probe/test/socialDeliberationProvider.test.ts
@@ -166,6 +166,80 @@ test("Deliberation parser omits an empty started_at_turn_ref instead of failing 
   assert.equal(result.ok && result.output.next_episode.started_at_turn_ref, undefined);
 });
 
+test("Deliberation parser falls back to current episode for blank required purpose/current_focus", () => {
+  const currentEpisode = activeEpisode();
+  const result = parseDeliberationProviderOutput(
+    {
+      deliberation: {
+        rationale: "Provider left required prose fields blank.",
+        next_episode: {
+          episode_id: "episode-cycle-0002",
+          actor_id: "npc_b",
+          purpose: "",
+          current_focus: "",
+          opened_from_refs: ["provider-outputs/deliberation.json"],
+          status: "active"
+        },
+        plan_bead_op_proposals: []
+      }
+    },
+    {
+      branchId: "branch-cycle-0001-blank-prose",
+      currentEpisodeRef: "goals/episodes/episode-cycle-0001.json",
+      currentEpisode,
+      branchEvidenceRefs: []
+    }
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.output.next_episode.purpose, currentEpisode.purpose);
+  assert.equal(result.ok && result.output.next_episode.current_focus, currentEpisode.current_focus);
+});
+
+test("Deliberation parser strips forbidden executable-authority keys from PlanBead proposals", () => {
+  const currentEpisode = activeEpisode();
+  const result = parseDeliberationProviderOutput(
+    {
+      deliberation: {
+        rationale: "Provider attached executable args to a PlanBead proposal.",
+        next_episode: {
+          episode_id: "episode-cycle-0002",
+          actor_id: "npc_b",
+          purpose: "Continue the prior crafting concern.",
+          current_focus: "Confirm a reachable crafting table before tool work.",
+          opened_from_refs: ["provider-outputs/deliberation.json"],
+          status: "active"
+        },
+        plan_bead_op_proposals: [
+          {
+            schema: "plan-bead-operation/v1",
+            op: "create",
+            bead_id: "pb-station-access",
+            rationale: "Keep crafting-table access visible.",
+            args: { primitive_id: "place_block", x: 1, y: 64, z: 2 },
+            patch: {
+              title: "Confirm crafting table access",
+              description: "Verify the observed crafting table is reachable before crafting tools.",
+              acceptance_evidence_required: ["runtime evidence the table is usable"],
+              notes_next: ["walk to the observed crafting table"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      branchId: "branch-cycle-0001-args",
+      currentEpisodeRef: "goals/episodes/episode-cycle-0001.json",
+      currentEpisode,
+      branchEvidenceRefs: []
+    }
+  );
+
+  assert.equal(result.ok, true);
+  const proposal = result.ok ? (result.output.plan_bead_op_proposals[0] as Record<string, unknown>) : {};
+  assert.equal("args" in proposal, false);
+});
+
 test("Deliberation parser carries current Active Episode fields and normalizes concrete PlanBead creates", () => {
   const currentEpisode = activeEpisode();
   const result = parseDeliberationProviderOutput(


### PR DESCRIPTION
## Why

On a long parallel run (10 agents, no-think Qwen) the social-cycle runtime kept
losing agents one at a time. Each death was a **recoverable malformed field in
the deliberation output that aborted the entire run**:

| Agent | Died at | provider_error |
|---|---|---|
| npc_b | cycle 34 | `next_episode.current_focus must be a non-empty string` |
| npc_d | cycle 18 | `next_episode.current_focus must be a non-empty string` |
| npc_c | cycle 12 | `plan_bead_op_proposals[0].args must not appear in Deliberation output` |
| (orig) | cycle 2 | `next_episode.started_at_turn_ref must be a non-empty string when present` |

This contradicts the repo's own PlanBeads principle: *a malformed candidate
should be repaired/rejected, not fail the whole judgment*. Deliberation was
doing the opposite — one bad field from a low-cost provider killed an
otherwise-productive long run.

## What changed (`parseDeliberationProviderOutput`)

- **Optional blank ref**: omit `started_at_turn_ref` when empty instead of
  carrying `""` to validation (mirrors `episodeContextProjection`).
- **Required blank prose**: fall back to the current episode for `purpose` and
  `current_focus` when the provider leaves them blank (same pattern already used
  for `actor_id`/`life_goal_ref`).
- **Forbidden keys**: deep-strip executable-authority keys (`args`,
  `parameters`, `primitive_id`, …) from PlanBead proposals via a new exported
  `stripExecutableAuthorityKeys`, single-sourced beside the validator's
  forbidden-key set.

Net: malformed → repair/skip the bad bit and keep going, instead of crashing.

## Before / After

`probe:social-cycle --actor npc_b --cycles 30 --isolate-workspace`:

| | Before | After |
|---|---|---|
| runtime_status | failed | passed |
| cycles | 1 | 30 (15/30 verified_progress) |
| provider_error | validation crash | none |

Each fix also has a deterministic regression test that **fails without the fix**
(verified by reverting), so the before/after reproduces in CI with no live
provider.

## Validation

- `cd probe && bun run typecheck` — clean
- `cd probe && bun test test/socialDeliberationProvider.test.ts` — **10 pass**
  (the 3 regression tests fail without their fixes)

## Limitations / Notes

- Provider-agnostic; the live evidence used a self-hosted Qwen via separate
  local changes, but every failure reproduces deterministically in the tests.
- Scoped to deliberation-output robustness (one clear purpose), per
  `CONTRIBUTING.md`. Two commits: the original narrow fix, then the generalized
  hardening found via the 10-agent run.
