### PR TITLE
runtime: recover from unparseable and empty-tool-call actor turns

### DIFF
--- a/probe/src/runtime/socialCycleRunner.ts
+++ b/probe/src/runtime/socialCycleRunner.ts
@@ -246,10 +246,30 @@ function appendProviderErrorRefs(input: {
   });
 }
 
-function actorTurnProviderFailureKind(
+/**
+ * Actor Turn provider failures the runtime records as a rejected action attempt
+ * and recovers from, instead of aborting the whole multi-cycle run.
+ *
+ * @remarks These are turns where the model returned a completion the runtime
+ * could not use — a rejected proposal, an unparseable tool selection, or an
+ * empty tool-call array — so the next turn shares the same context and may
+ * succeed. Standing conditions (missing key, exhausted budget/quota, billing,
+ * unknown model, infra outage) are deliberately excluded and stay fatal: every
+ * retry would hit the same wall.
+ */
+export function isRecoverableActorTurnProviderFailure(
   result: ActorTurnProviderResult | ActionPlannerProviderResult
 ) {
-  return !result.ok && "failureKind" in result ? result.failureKind : undefined;
+  if (result.ok) {
+    return false;
+  }
+  const failureKind = "failureKind" in result ? result.failureKind : undefined;
+  const errorKind = "errorKind" in result ? result.errorKind : undefined;
+  return (
+    failureKind === "provider_contract_rejection" ||
+    errorKind === "tool_selection_parse_error" ||
+    errorKind === "tool_call_error"
+  );
 }
 
 async function buildActorTurnProviderContractRejectionAttempt(input: {
@@ -1475,7 +1495,7 @@ export async function runSocialCycle(input: SocialCycleRunOptions): Promise<Soci
         if (!planner.ok) {
           if (
             actionHotPath === "actor_turn" &&
-            actorTurnProviderFailureKind(planner) === "provider_contract_rejection"
+            isRecoverableActorTurnProviderFailure(planner)
           ) {
             const contractRejection = await buildActorTurnProviderContractRejectionAttempt({
               rootDir,

--- a/probe/test/socialCycleRunner.test.ts
+++ b/probe/test/socialCycleRunner.test.ts
@@ -6,10 +6,12 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  isRecoverableActorTurnProviderFailure,
   runSocialCycle,
   selectGeminiFallbackModelsForCall,
   selectGeminiModelForCall
 } from "../src/runtime/socialCycleRunner.js";
+import type { ActorTurnProviderResult } from "../src/provider/socialActorTurnProvider.js";
 import { cycleGoalProviderInputIncludesSoulAndLifeGoal } from "../src/runtime/goals/types.js";
 import { readJsonIfExists } from "../src/runtime/goals/goalJsonStore.js";
 import { initializeActorWorkspaces } from "../src/runtime/actorWorkspace.js";
@@ -198,6 +200,50 @@ test("Gemini social-cycle model rotation selects one model per provider call", (
       fallbackModel: "gemini-3-flash-preview"
     }),
     ["gemini-2.5-flash", "gemini-3.1-flash-lite"]
+  );
+});
+
+test("actor-turn recoverable failures cover rejected/unparseable/empty-tool-call turns", () => {
+  const baseFailure = {
+    ok: false as const,
+    error: "boom",
+    inputRef: "provider-inputs/in.json",
+    outputRef: "provider-outputs/out.json"
+  };
+  const recoverable: ActorTurnProviderResult[] = [
+    { ...baseFailure, failureKind: "provider_contract_rejection" },
+    { ...baseFailure, errorKind: "tool_selection_parse_error" },
+    { ...baseFailure, errorKind: "tool_call_error" }
+  ];
+  for (const result of recoverable) {
+    assert.equal(isRecoverableActorTurnProviderFailure(result), true);
+  }
+
+  // Standing conditions stay fatal: every retry hits the same wall, so the run
+  // must abort rather than churn cycles recording identical rejections.
+  const fatalErrorKinds = [
+    "missing_api_key",
+    "usage_budget_exceeded",
+    "model_not_found",
+    "quota",
+    "billing",
+    "rate_limit",
+    "timeout",
+    "server_error",
+    "api_error"
+  ];
+  for (const errorKind of fatalErrorKinds) {
+    assert.equal(
+      isRecoverableActorTurnProviderFailure({ ...baseFailure, errorKind }),
+      false,
+      `${errorKind} must not be recoverable`
+    );
+  }
+
+  // A successful provider result is never a failure to recover from.
+  assert.equal(
+    isRecoverableActorTurnProviderFailure({ ok: true } as unknown as ActorTurnProviderResult),
+    false
   );
 });
 


### PR DESCRIPTION
## Why
Only `provider_contract_rejection` actor-turn failures were recorded as a rejected attempt and allowed to continue; every other failure set `providerFailed` and aborted the whole multi-cycle run.

Live runs against a self-hosted OpenAI-compatible model showed two recoverable, per-turn imperfections each killing an actor at cycle 1–3:
- `tool_selection_parse_error` — the model selected a hidden/unknown tool or sent malformed `tool_args`.
- `tool_call_error` — the provider returned no tool_calls at all.

The next turn shares the same context and may succeed, so these should be recorded and continued, not fatal.

## What changed
- Replace `actorTurnProviderFailureKind` with `isRecoverableActorTurnProviderFailure`, an explicit allowlist. `provider_contract_rejection`, `tool_selection_parse_error`, and `tool_call_error` are recorded as a rejected attempt (reusing `buildActorTurnProviderContractRejectionAttempt`) and the run continues. The recorded rejection feeds the next turn's `recentActionAttempts`/evidence.
- Standing conditions (missing key, budget/quota, billing, unknown model, infra outage) stay fatal so a dead provider still aborts; `goal_mind`/`deliberation` remain the loud backstop for a fully broken deployment.
- Add a unit test asserting the recoverable vs fatal classification.

## Validation
- `cd probe && bun run typecheck`
- `cd probe && bun test test/socialCycleRunner.test.ts` (12 pass)
- Live 5-agent run: all agents cleared the cycle 3–8 death zone; recorded rejections instead of `runtime_status: failed` (one agent completed 30/30 with `passed`).

## Known limitations
This buys survival, not usefulness. A run that completes entirely via recovered rejections still reports `runtime_status: "blocked"` with `gameplay_progress_verified: false`, so it never launders into a pass.