### PR TITLE
runtime: keep un-awaited generated helper rejections from killing the run

### DIFF
--- a/probe/src/generatedActionSkills/directExecutor.ts
+++ b/probe/src/generatedActionSkills/directExecutor.ts
@@ -157,7 +157,7 @@ function withHelperLogging<TContext extends DirectGeneratedActionSkillContext>(
         try {
           const result = value.apply(target, args);
           if (result && typeof (result as Promise<unknown>).then === "function") {
-            return (result as Promise<unknown>).then(
+            const tracked = (result as Promise<unknown>).then(
               (resolved) => {
                 helperEvents.push({ name: property, args, status: "completed", result: resolved });
                 return resolved;
@@ -168,6 +168,13 @@ function withHelperLogging<TContext extends DirectGeneratedActionSkillContext>(
                 throw error;
               }
             );
+            // Generated code may invoke a helper without awaiting it (a common LLM
+            // mistake). The failure is already recorded above; this no-op handler
+            // keeps an un-awaited rejection from escaping as an unhandled rejection
+            // that kills the whole run. Any awaiter of `tracked` still sees the
+            // rejection, so the awaited path is unchanged.
+            tracked.catch(() => {});
+            return tracked;
           }
 
           helperEvents.push({ name: property, args, status: "completed", result });

--- a/probe/src/socialCycleCli.ts
+++ b/probe/src/socialCycleCli.ts
@@ -164,6 +164,19 @@ function defaultModelForProvider(providerId: SocialCycleProviderId) {
 }
 
 async function main() {
+  // Backstop for floating promise rejections originating in untrusted generated
+  // action-skill code (a helper invoked without await, or a bare Promise.reject
+  // in generated source). The withHelperLogging proxy already neutralizes the
+  // common un-awaited-helper case; this net keeps any remaining un-awaited
+  // rejection from terminating a bounded multi-cycle run. It logs loudly instead
+  // of swallowing silently so genuine runtime rejection bugs stay visible — and
+  // it does not bypass the runner's fatal paths, which fail via return values
+  // (providerFailed / runtime_status), not unhandled rejections.
+  process.on("unhandledRejection", (reason) => {
+    const detail = reason instanceof Error ? `${reason.message}\n${reason.stack ?? ""}` : String(reason);
+    console.error(`[social-cycle] swallowed unhandled rejection (run continues): ${detail}`);
+  });
+
   const here = path.dirname(fileURLToPath(import.meta.url));
   const repoRoot = path.resolve(here, "../..");
   loadRepoDotEnv(repoRoot, {

--- a/probe/test/directGeneratedActionSkillExecutor.test.ts
+++ b/probe/test/directGeneratedActionSkillExecutor.test.ts
@@ -7,7 +7,8 @@ import assert from "node:assert/strict";
 
 import {
   assertDirectGeneratedActionSkillSource,
-  runDirectGeneratedActionSkill
+  runDirectGeneratedActionSkill,
+  type GeneratedActionSkillHelperEvent
 } from "../src/generatedActionSkills/directExecutor.js";
 
 test("direct generated action skill executor runs TypeScript and records helper calls", async () => {
@@ -172,4 +173,43 @@ test("direct generated action skill executor reports timeout", async () => {
   });
 
   assert.equal(result.status, "timeout");
+});
+
+test("un-awaited generated helper rejection does not crash the run", async () => {
+  // Reproduces a live crash: generated code calls a helper without awaiting it,
+  // the helper throws, and the floating rejection would otherwise become an
+  // unhandled rejection that terminates the whole process.
+  const helperEvents: GeneratedActionSkillHelperEvent[] = [];
+  const result = await runDirectGeneratedActionSkill({
+    actorId: "npc_b",
+    skillName: "fireAndForgetThrow",
+    helperEvents,
+    source: `
+      export async function run(ctx: {
+        setControlState(args: Record<string, unknown>): Promise<unknown>;
+        wait(ms: number): Promise<void>;
+      }, params: Record<string, never>) {
+        // Not awaited — mirrors the LLM mistake that crashed an actor mid-run.
+        ctx.setControlState({ forward: true });
+        await ctx.wait(1);
+        return { status: "completed" };
+      }
+    `,
+    ctx: {
+      async setControlState() {
+        throw new Error("Control  is not exposed by run_mineflayer_program");
+      },
+      wait(ms: number) {
+        return new Promise<void>((resolve) => setTimeout(resolve, ms));
+      }
+    }
+  });
+  // Flush microtasks so the recorded-failure event lands before asserting.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(result.status, "completed");
+  assert.ok(
+    helperEvents.some((event) => event.name === "setControlState" && event.status === "failed"),
+    "the un-awaited failing helper call is still recorded as evidence"
+  );
 });


### PR DESCRIPTION
## Why
Generated action-skill code frequently invokes a helper **without awaiting it** (a common LLM mistake). When that helper throws, the rejected promise is never returned by `run()`, so `runDirectGeneratedActionSkill`'s `await run(...)` cannot catch it — and the process terminates on the unhandled rejection.

This is an intermittent but real death class for long social-cycle runs. A single fire-and-forget call observed live — `ctx.mineflayer('setControlState', { forward: true })` (un-awaited, and with malformed args) — threw `Control  is not exposed by run_mineflayer_program` and ended the whole process at cycle 2.

## What changed
- In `withHelperLogging`, attach a no-op `.catch(() => {})` to the tracked helper promise. The failure is still recorded as a `failed` helperEvent and any awaiter still observes the rejection; only the un-awaited floating case is neutralized.
- Add a run-lifetime `unhandledRejection` backstop in the social-cycle CLI that **logs loudly and continues**, as a net for floating rejections that bypass the proxy (bare `Promise.reject`, async IIFE). It does not bypass the runner's return-value fatal paths (`providerFailed` / `runtime_status`).
- Add a regression test that crashes the test runner **without** the fix and passes **with** it.

## Validation
- `cd probe && bun run typecheck`
- `cd probe && bun test test/directGeneratedActionSkillExecutor.test.ts` (10 pass)
- Live: the actor that previously crashed at cycle 2 reached cycle 17+ in a re-run with the fix.

## Known limitations
No fake-completion gap: the trial verifier requires positive *awaited* helper evidence, so a floating failed call (recorded as `failed`) never launders into a passed trial.