### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy-docs.yml
+++ b/.github/workflows/test-deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: pages-test-${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/gigio1023/minecraft-llm-agent-community/security/code-scanning/1](https://github.com/gigio1023/minecraft-llm-agent-community/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: set workflow-level permissions to `contents: read` (minimal needed for `actions/checkout` and reading repository contents). This preserves current behavior and documents intent.

**File to edit:** `.github/workflows/test-deploy-docs.yml`  
**Change location:** after the `on:` trigger block (before `concurrency:` is a clean location).  
**No imports/methods/dependencies needed** (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
