### PR TITLE
runtime: improve actor-turn prefix-cache reuse (stable-first order + stable action_cards)

### DIFF
--- a/probe/src/runtime/goals/actorEpisode/actionCardSelection.ts
+++ b/probe/src/runtime/goals/actorEpisode/actionCardSelection.ts
@@ -1,18 +1,19 @@
 import type { ActionCardProjection } from "./actionCards.js";
-import type { ActorTurnCurrentStateProjection } from "./types.js";
 import { unique } from "./projectionUtils.js";
 
 /**
- * Adds provider-visible hints without selecting, hiding, or rejecting actions.
+ * Appends static, parameter-shaping guidance to specific Action Cards without
+ * selecting, hiding, or rejecting actions.
  *
- * @remarks This module must stay out of the Minecraft-planner business. It may
- * surface structured current-state facts that are already in `ActorTurnInput`,
- * but it must not parse prose requirements, compute recipe eligibility, hide
- * tools, inject defaults, or decide which Action Card the LLM should choose.
+ * @remarks Hints stay turn-invariant so the large `action_cards` block remains a
+ * stable prompt prefix (reused by inference prefix caches); live
+ * shared_storage/deposit values are read from `current_state`, not inlined here.
+ * This module must not parse prose
+ * requirements, compute recipe eligibility, hide tools, inject defaults, or
+ * decide which Action Card the LLM should choose.
  */
-export function annotateActionCardsWithCurrentStateHints(
-  projection: ActionCardProjection,
-  currentState: ActorTurnCurrentStateProjection
+export function annotateActionCardsWithStaticParameterHints(
+  projection: ActionCardProjection
 ): ActionCardProjection {
   const actionCards = projection.action_cards.map((card) => {
     if (card.title === "Inspect Chest" || card.title === "Inspect Shared Chest") {
@@ -21,17 +22,7 @@ export function annotateActionCardsWithCurrentStateHints(
         parameter_hints: unique([
           ...card.parameter_hints,
           "Use empty parameters for the bounded shared-chest container snapshot/openability action.",
-          `Current shared_storage status: ${currentState.shared_storage.status}.`,
-          ...(currentState.shared_storage.items.length > 0
-            ? [
-                `Known shared_storage items: ${currentState.shared_storage.items
-                  .map((item) => `${item.name}:${item.count}`)
-                  .join(", ")}.`
-              ]
-            : []),
-          ...(currentState.shared_storage.evidence_refs.length > 0
-            ? [`Shared storage evidence refs: ${currentState.shared_storage.evidence_refs.join(", ")}.`]
-            : [])
+          "Read the live shared_storage status, items, and evidence from current_state.shared_storage."
         ])
       };
     }
@@ -39,22 +30,11 @@ export function annotateActionCardsWithCurrentStateHints(
     if (card.title === "Deposit Shared" ||
       card.title === "Deposit Shared Items" ||
       card.title === "Handoff Item At Chest") {
-      const candidates = currentState.deposit_candidates.slice(0, 6);
       return {
         ...card,
         parameter_hints: unique([
           ...card.parameter_hints,
-          ...(candidates.length > 0
-            ? [
-                `Current deposit candidates: ${candidates
-                  .map((candidate) =>
-                    `${candidate.itemName} inventory=${candidate.inventoryCount} suggestedCount=${candidate.suggestedCount}${
-                      candidate.socially_requested ? " socially_requested" : ""
-                    }`
-                  )
-                  .join("; ")}.`
-              ]
-            : ["No deposit candidates are currently projected from inventory/social context."]),
+          "Read current_state.deposit_candidates for itemName, inventoryCount, suggestedCount, and socially_requested.",
           "If choosing this Action Card, provide explicit itemName and count in parameters; runtime will not infer them from prose."
         ])
       };

--- a/probe/src/runtime/goals/actorEpisode/turnInput.ts
+++ b/probe/src/runtime/goals/actorEpisode/turnInput.ts
@@ -44,37 +44,41 @@ export function buildActorTurnInput(input: {
     activeEpisode: input.activeEpisode,
     context: input.context
   });
+  // Key order is the serialized prompt order, which sets the prompt prefix-cache
+  // boundary (inference backends reuse the prefix up to the first byte that
+  // changes between turns). Keep cache-stable blocks first and turn-volatile
+  // fields last.
   const actorTurnInput: ActorTurnInput = {
     schema: "actor-turn-input/v1",
-    turn_id: input.turnId,
-    decision_frame: buildActorTurnDecisionFrame({
-      activeEpisode,
-      currentState,
-      actionCardProjection,
-      recentEvidenceTrace
-    }),
-    active_episode: activeEpisode,
+    minecraft_basic_guide: buildMinecraftBasicGuideProjection(),
+    mineflayer_codegen_skill: buildMineflayerCodegenSkillProjection(),
+    action_cards: actionCardProjection.action_cards,
     actor_context: {
       actor_id: input.context.ActorSoul.actor_id,
       actor_soul_ref: soulRef(input.context.ActorSoul.actor_id),
       life_goal_ref: lifeGoalRef(),
       life_goal_summary: input.context.ActorLifeGoal.objective
     },
-    current_observation_refs: [...input.currentObservationRefs],
-    current_state: currentState,
-    recent_evidence_trace: recentEvidenceTrace,
-    compact_plan_bead_hints: planBeadHintsFromContext(input.context),
-    memory_refs: memoryRefsFromContext(input.context),
     relationship_context: buildRelationshipContextProjection(input.context),
-    runtime_retry_constraints: retryConstraintSummaries(input.context),
-    action_cards: actionCardProjection.action_cards,
-    minecraft_basic_guide: buildMinecraftBasicGuideProjection(),
-    mineflayer_codegen_skill: buildMineflayerCodegenSkillProjection(),
+    compact_plan_bead_hints: planBeadHintsFromContext(input.context),
+    current_observation_refs: [...input.currentObservationRefs],
     provider_budget_hint: input.providerBudgetHint ?? {
       provider_id: "unknown",
       model: "unknown",
       status: "unknown"
-    }
+    },
+    turn_id: input.turnId,
+    active_episode: activeEpisode,
+    decision_frame: buildActorTurnDecisionFrame({
+      activeEpisode,
+      currentState,
+      actionCardProjection,
+      recentEvidenceTrace
+    }),
+    current_state: currentState,
+    recent_evidence_trace: recentEvidenceTrace,
+    memory_refs: memoryRefsFromContext(input.context),
+    runtime_retry_constraints: retryConstraintSummaries(input.context)
   };
   return { actorTurnInput, actionCardProjection };
 }

--- a/probe/src/runtime/goals/actorEpisode/turnInput.ts
+++ b/probe/src/runtime/goals/actorEpisode/turnInput.ts
@@ -8,7 +8,7 @@ import { soulRef } from "../actorSoulStore.js";
 import { lifeGoalRef } from "../lifeGoalStore.js";
 import type { SocialCycleContextPacket } from "../cycleContextAssembler.js";
 import { buildActionCardProjection, type ActionCardProjection } from "./actionCards.js";
-import { annotateActionCardsWithCurrentStateHints } from "./actionCardSelection.js";
+import { annotateActionCardsWithStaticParameterHints } from "./actionCardSelection.js";
 import { buildActorTurnCurrentStateProjection } from "./currentStateProjection.js";
 import { buildActorTurnDecisionFrame } from "./decisionFrame.js";
 import {
@@ -37,9 +37,8 @@ export function buildActorTurnInput(input: {
 }): { actorTurnInput: ActorTurnInput; actionCardProjection: ActionCardProjection } {
   const currentState = buildActorTurnCurrentStateProjection(input.context);
   const recentEvidenceTrace = [...(input.recentEvidenceTrace ?? [])];
-  const actionCardProjection = annotateActionCardsWithCurrentStateHints(
-    buildActionCardProjection(input.context.action_surface),
-    currentState
+  const actionCardProjection = annotateActionCardsWithStaticParameterHints(
+    buildActionCardProjection(input.context.action_surface)
   );
   const activeEpisode = anchorActiveEpisodeToPlanBeadContext({
     activeEpisode: input.activeEpisode,

--- a/probe/test/actorTurnProviderInput.test.ts
+++ b/probe/test/actorTurnProviderInput.test.ts
@@ -1217,7 +1217,7 @@ test("Actor Turn input exposes shared-storage deposit candidates from inventory 
   assert.ok(handoffCard);
   assert.ok(
     depositCard.parameter_hints.some((hint) =>
-      hint.includes("oak_log inventory=4 suggestedCount=1 socially_requested")
+      hint.includes("Read current_state.deposit_candidates")
     )
   );
   assert.ok(
@@ -1301,7 +1301,7 @@ test("Actor Turn input marks Inspect Chest as the bounded container openability 
   );
   assert.ok(
     inspectCard.parameter_hints.some((hint) =>
-      hint.includes("Current shared_storage status")
+      hint.includes("current_state.shared_storage")
     )
   );
 });
@@ -1399,7 +1399,7 @@ test("Actor Turn input does not keep a completed one-item shared-storage request
   assert.ok(actorTurnInput.action_cards.find((card) => card.title === "Inspect Chest"));
   assert.ok(
     depositCard.parameter_hints.some((hint) =>
-      hint.includes("Current deposit candidates") && !hint.includes("socially_requested")
+      hint.includes("Read current_state.deposit_candidates")
     )
   );
   assert.ok(


### PR DESCRIPTION
The actor-turn prompt is prefill-bound and largely identical turn-to-turn, so the prompt prefix cache (reused by inference backends) is the dominant latency lever. Two composing changes make the cache actually reusable.

## 1. Order the prompt stable-first (`turnInput.ts`)
The serialized key order of the input object **is** the prompt order, which sets the cache boundary (caching reuses the contiguous prefix up to the first byte that changes between turns).

Previously the object emitted turn-volatile fields first (`turn_id`, `decision_frame`, `active_episode`, `current_state`, …), so the prefix broke almost immediately and never reached the large static blocks. Now `buildActorTurnInput` emits the cache-stable blocks first (`minecraft_basic_guide`, `mineflayer_codegen_skill`, `action_cards`, `actor_context`, `relationship_context`, `compact_plan_bead_hints`, `current_observation_refs`, `provider_budget_hint`) and the turn-volatile fields last. Pure reorder — identical fields and values.

## 2. Keep `action_cards` byte-stable (`actionCardSelection.ts`)
With the stable blocks now in front, `action_cards` (~9k tokens) sits in the cached prefix — but it was annotated per-turn with live `shared_storage` / `deposit_candidates` values, so it re-broke the prefix whenever that state changed.

`annotateActionCardsWithCurrentStateHints` → `annotateActionCardsWithStaticParameterHints`: it drops the inlined dynamic values and instead points the model at `current_state.shared_storage` / `current_state.deposit_candidates`. That data is already a strict subset of the `current_state` block sent every turn, and open social requests remain in `decision_frame.open_social_requests`, so no information or decision support is lost. The input tests that pinned the inlined hints now assert the static pointers; every `current_state` / `decision_frame` assertion is unchanged.

The two changes compose: #1 puts the stable blocks in the cached prefix; #2 keeps `action_cards` from re-breaking it.

## Validation
Self-hosted Qwen3.6-27B on vLLM, 5 concurrent agents — numbers are deployment/load-specific:
- `cd probe && bun run typecheck`
- `cd probe && bun test test/actorTurnProviderInput.test.ts` (38 pass)
- KV-cache usage measured at **0%** during the runs → prefill is redundant, not memory-bound, so the prefix cache is the right lever (not eviction).
- With the stable-first order but `action_cards` still inlining live state: prefix-cache hit rate was **volatile ~11–73% (≈50% over a 5-min window)**.
- After de-annotating `action_cards`: **~58% incremental** hit rate (Δhits/Δqueries over the run), **~62%** in a longer warm run.
- The reorder itself is not separately benchmarked (no natural-order baseline was captured on the cache-enabled deployment); it is the precondition that puts the stable blocks into the cached prefix.

## Known limitations
The remaining ceiling is the still-growing `active_episode` tail (it balloons over a long run); compacting it is the next lever and is out of scope here.