### PR TITLE
runtime: bound actor-turn lineage refs in the hot-packet projection

### DIFF
--- a/probe/src/runtime/goals/actorEpisode/episodeContextProjection.ts
+++ b/probe/src/runtime/goals/actorEpisode/episodeContextProjection.ts
@@ -140,6 +140,33 @@ export function anchorActiveEpisodeToPlanBeadContext(input: {
   };
 }
 
+/** Max `opened_from_refs` kept in the hot packet; the rest stays in the stored record. */
+export const ACTIVE_EPISODE_HOT_LINEAGE_LIMIT = 16;
+
+/**
+ * Bounds the lineage refs an Active Episode carries into the Actor Turn hot
+ * packet.
+ *
+ * @remarks `opened_from_refs` is audit/lineage only: no Actor Turn decision
+ * reads it, and branch detection reads the stored episode, not this projection.
+ * Returns a fresh object and never mutates the stored record, so the full
+ * lineage stays fetchable and the write-site dedup keeps seeing every ref.
+ */
+export function boundActiveEpisodeLineageForHotPacket(
+  episode: ActiveEpisode,
+  recentRefLimit = ACTIVE_EPISODE_HOT_LINEAGE_LIMIT
+): ActiveEpisode {
+  const refs = episode.opened_from_refs;
+  if (refs.length <= recentRefLimit) {
+    return episode;
+  }
+  return {
+    ...episode,
+    opened_from_refs: refs.slice(-recentRefLimit),
+    opened_from_refs_omitted_count: refs.length - recentRefLimit
+  };
+}
+
 export function retryConstraintSummaries(context: SocialCycleContextPacket) {
   return context.runtime_retry_constraints.map((constraint) => ({
     constraint_id: constraint.constraint_id,

--- a/probe/src/runtime/goals/actorEpisode/turnInput.ts
+++ b/probe/src/runtime/goals/actorEpisode/turnInput.ts
@@ -13,6 +13,7 @@ import { buildActorTurnCurrentStateProjection } from "./currentStateProjection.j
 import { buildActorTurnDecisionFrame } from "./decisionFrame.js";
 import {
   anchorActiveEpisodeToPlanBeadContext,
+  boundActiveEpisodeLineageForHotPacket,
   buildRelationshipContextProjection,
   memoryRefsFromContext,
   planBeadHintsFromContext,
@@ -41,10 +42,12 @@ export function buildActorTurnInput(input: {
     buildActionCardProjection(input.context.action_surface),
     currentState
   );
-  const activeEpisode = anchorActiveEpisodeToPlanBeadContext({
-    activeEpisode: input.activeEpisode,
-    context: input.context
-  });
+  const activeEpisode = boundActiveEpisodeLineageForHotPacket(
+    anchorActiveEpisodeToPlanBeadContext({
+      activeEpisode: input.activeEpisode,
+      context: input.context
+    })
+  );
   const actorTurnInput: ActorTurnInput = {
     schema: "actor-turn-input/v1",
     turn_id: input.turnId,

--- a/probe/src/runtime/goals/actorEpisode/types.ts
+++ b/probe/src/runtime/goals/actorEpisode/types.ts
@@ -367,6 +367,11 @@ export type ActiveEpisode = {
   };
   social_pressure: SocialPressureSummary[];
   opened_from_refs: string[];
+  /**
+   * Count of `opened_from_refs` omitted by hot-packet lineage windowing. Absent
+   * on persisted records (nothing omitted); set only on the Actor Turn projection.
+   */
+  opened_from_refs_omitted_count?: number;
   started_at_turn_ref?: string;
   status: ActiveEpisodeStatus;
 };

--- a/probe/test/actorTurnProviderInput.test.ts
+++ b/probe/test/actorTurnProviderInput.test.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 import { assembleSocialCycleContext } from "../src/runtime/goals/cycleContextAssembler.js";
 import { compileActorSoulFromProfile } from "../src/runtime/goals/actorSoulStore.js";
 import {
+  ACTIVE_EPISODE_HOT_LINEAGE_LIMIT,
+  boundActiveEpisodeLineageForHotPacket,
   buildActionCardProjection,
   buildActiveEpisodeFromCycleGoal,
   buildActorTurnInput,
@@ -27,7 +29,7 @@ import {
   parseActorTurnToolSelection
 } from "../src/provider/socialActorTurnProvider.js";
 import type { ActorTurnAuthorMineflayerActionArgs } from "../src/provider/socialActorTurnToolParser.js";
-import type { ActorTurnInput } from "../src/runtime/goals/actorEpisode/index.js";
+import type { ActiveEpisode, ActorTurnInput } from "../src/runtime/goals/actorEpisode/index.js";
 import type { PlanBeadPacket } from "../src/runtime/goals/planBeads/index.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -3191,4 +3193,133 @@ test("Gemini GenAI function calls parse through the Actor Turn tool-selection co
     assert.equal(parsed.selection.call_id, "gemini-call-1");
     assert.match(parsed.selection.args.why_codegen_is_needed, /placement-cell/);
   }
+});
+
+// --- #1: bounded hot-packet lineage projection (Low-Cost "hot pointer plus
+// artifact ref" discipline). opened_from_refs accumulates one+ ref per
+// deliberation and is audit/lineage only; the runtime's own branch detection
+// reads the stored episode, so windowing the hot packet is behavior-safe. ---
+
+function episodeWithOpenedRefs(openedFromRefs: string[]): ActiveEpisode {
+  return {
+    schema: "active-episode/v1",
+    episode_id: "episode-lineage-test",
+    actor_id: "npc_b",
+    life_goal_ref: "goals/life/life-goal.json",
+    purpose: "exercise lineage windowing",
+    current_focus: "keep the hot packet bounded",
+    actors_visible_or_relevant: [],
+    selected_plan_bead_refs: [],
+    related_plan_bead_refs: [],
+    opened_from_refs: openedFromRefs,
+    success_signals: [],
+    pivot_triggers: [],
+    social_pressure: [],
+    mistake_budget: {
+      allow_exploration_turns: 2,
+      observe_repeat_limit: 1,
+      exact_blocker_repeat_limit: 2
+    },
+    status: "active"
+  };
+}
+
+test("hot-packet lineage projection windows opened_from_refs without mutating the stored record", () => {
+  const fullRefs = Array.from(
+    { length: ACTIVE_EPISODE_HOT_LINEAGE_LIMIT + 50 },
+    (_, index) => `lineage/ref-${index}.json`
+  );
+  const stored = episodeWithOpenedRefs(fullRefs);
+  const projected = boundActiveEpisodeLineageForHotPacket(stored);
+
+  // Bound holds vs age: the hot view never exceeds the limit.
+  assert.equal(projected.opened_from_refs.length, ACTIVE_EPISODE_HOT_LINEAGE_LIMIT);
+  // Recency: the most recent refs are kept (lineage tail), not the oldest.
+  assert.deepEqual(
+    projected.opened_from_refs,
+    fullRefs.slice(-ACTIVE_EPISODE_HOT_LINEAGE_LIMIT)
+  );
+  // No silent cap: the omitted count is surfaced as a typed number.
+  assert.equal(projected.opened_from_refs_omitted_count, 50);
+
+  // Fetchability + dedup safety: the stored record is untouched, so the full
+  // lineage remains the source of truth and the deliberation write-site dedup
+  // still sees every ref (no episode re-open regression).
+  assert.equal(stored.opened_from_refs.length, fullRefs.length);
+  assert.equal(stored.opened_from_refs_omitted_count, undefined);
+  assert.notEqual(projected, stored);
+});
+
+test("hot-packet lineage projection is a no-op at or under the limit", () => {
+  const refs = Array.from(
+    { length: ACTIVE_EPISODE_HOT_LINEAGE_LIMIT },
+    (_, index) => `lineage/ref-${index}.json`
+  );
+  const stored = episodeWithOpenedRefs(refs);
+  const projected = boundActiveEpisodeLineageForHotPacket(stored);
+  assert.equal(projected, stored);
+  assert.equal(projected.opened_from_refs_omitted_count, undefined);
+});
+
+test("buildActorTurnInput bounds lineage in both active_episode and decision_frame", async () => {
+  const soul = compileActorSoulFromProfile("npc_b");
+  const context = await assembleSocialCycleContext({
+    actorWorkspaceRootDir: rootDir,
+    actorId: "npc_b",
+    soul,
+    lifeGoal: lifeGoal(),
+    strategicGoals: [],
+    worldEvents: [],
+    previousJudgments: [],
+    activeActionSkills: [buildNpcBActionSkillRecord()],
+    observation: {
+      status: "ok",
+      observerId: "npc_b",
+      position: { x: 0, y: 64, z: 0 },
+      visibleActors: [],
+      inventory: [{ name: "crafting_table", count: 1 }],
+      nearbyBlocks: [{ name: "grass_block", position: { x: 1, y: 63, z: 0 } }]
+    },
+    allowedPrimitiveIds: ["observe", "move_to", "place_block", "say", "remember"],
+    maxActionsPerCycle: 1,
+    cycleIndex: 1,
+    planBeadPacket: planBeadPacket(),
+    runtimeRetryConstraints: []
+  });
+
+  const fullRefs = Array.from(
+    { length: ACTIVE_EPISODE_HOT_LINEAGE_LIMIT + 100 },
+    (_, index) => `lineage/ref-${index}.json`
+  );
+  const activeEpisode: ActiveEpisode = {
+    ...buildActiveEpisodeFromCycleGoal({
+      episodeId: "episode-cycle-0001",
+      context,
+      cycleGoal: cycleGoal(),
+      startedAtTurnRef: "turns/turn-001.json"
+    }),
+    status: "active",
+    opened_from_refs: fullRefs
+  };
+
+  const { actorTurnInput } = buildActorTurnInput({
+    turnId: "turn-001",
+    context,
+    activeEpisode,
+    currentObservationRefs: ["observations/cycle-0001.json"]
+  });
+
+  // Both packet consumers are windowed from the same projected episode.
+  assert.equal(
+    actorTurnInput.active_episode.opened_from_refs.length,
+    ACTIVE_EPISODE_HOT_LINEAGE_LIMIT
+  );
+  assert.ok(
+    actorTurnInput.decision_frame.episode_focus_status.evidence_refs.length <=
+      ACTIVE_EPISODE_HOT_LINEAGE_LIMIT
+  );
+  // The caller's stored episode object is never mutated by packet assembly.
+  assert.equal(activeEpisode.opened_from_refs.length, fullRefs.length);
+  // The projected packet still validates as a well-formed Actor Turn input.
+  assert.equal(validateActorTurnInput(actorTurnInput).ok, true);
 });


### PR DESCRIPTION
## Problem

`ActiveEpisode.opened_from_refs` accumulates one or more refs **per deliberation** and is audit/lineage only, but it is serialized **in full** into every Actor Turn provider packet. It grows `O(cycles)` and, on a real run, reached ~26% of the entire actor-turn prompt by cycle ~108 and kept climbing (≈2,700 refs projected by cycle 1000). That unbounded growth dominates the prompt and erodes the inference prefix cache, working directly against the Low-Cost spec's **Artifact And Context Discipline**:

> keep the hot provider packet small … the input does not include unbounded transcript bodies or full historical evidence payloads … omitted details remain fetchable from actor workspace refs.

## Change

Bound the refs in a **non-persisted hot-packet projection** — `boundActiveEpisodeLineageForHotPacket` keeps the most recent `ACTIVE_EPISODE_HOT_LINEAGE_LIMIT` (16) and records a typed `opened_from_refs_omitted_count`. It is applied once in `buildActorTurnInput`, so both `active_episode` and `decision_frame` consume the bounded view.

Key properties (the "hot pointer plus artifact ref" pattern, not truncation):

- **Stored record untouched.** The persisted `active-episode/v1` record keeps the full `opened_from_refs`, so the full lineage stays fetchable via the episode ref — nothing is destroyed or summarized into prose.
- **Write-site dedup unaffected.** The deliberation dedup reads the *stored* episode, not the packet, so windowing the projection cannot cause episode re-opens. The runtime's branch detection also reads the stored episode.
- **Additive, no migration.** `opened_from_refs_omitted_count` is an additive optional field; the `active-episode/v1` shape is unchanged.
- **No silent cap.** The omitted count is surfaced as a typed number.

## Impact

Measured on a real cycle-108 packet: actor-turn input **78k → 59k bytes (~24% smaller)**, and `O(1)` thereafter instead of unbounded growth.

## Tests

- bound holds vs age; most-recent refs kept (tail); omitted count surfaced
- **stored record not mutated** (fetchability + dedup safety)
- no-op at/under the limit
- integration: `buildActorTurnInput` windows both `active_episode` and `decision_frame`, the caller's episode is not mutated, and the projected packet still passes `validateActorTurnInput`

## Notes

Independent of #37 (prefix-cache ordering): the size bound helps regardless of key order, and the two compose (this keeps the volatile suffix from growing, #37 keeps the stable prefix first). Branched off `main`.
